### PR TITLE
Remove `includes` from `.cabal`-file

### DIFF
--- a/bzlib.cabal
+++ b/bzlib.cabal
@@ -38,7 +38,6 @@ library
     build-depends: fail < 5
   if os(windows)
     build-depends: base >= 4.11
-  includes:        bzlib.h
   ghc-options:     -Wall
   if !(os(windows) || impl(ghcjs) || os(ghcjs) || arch(wasm32))
     -- Normally we use the the standard system bz2 lib:


### PR DESCRIPTION
This is useless at best, and a common source of confusion.

https://github.com/haskell/cabal/pull/10145
https://github.com/sol/hpack/issues/355