### PR TITLE
Export `DecompressError` + Improve Documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
-## 0.5.2.1
+## 0.5.3.0
 
 * Add `DecompressError` to export list of `Codec.Compression.BZip.Internal`.
 * Copy some documentation from `zlib`.
+* Add argument documentation to functions in `Codec.Compression.BZip.Internal`.
 
 ## 0.5.2.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.5.2.1
+
+* Add `DecompressError` to export list of `Codec.Compression.BZip.Internal`.
+* Copy some documentation from `zlib`.
+
 ## 0.5.2.0
 
 * Fix CVE-2019-12900 by updating C sources to 1.0.8.

--- a/Codec/Compression/BZip/Internal.hs
+++ b/Codec/Compression/BZip/Internal.hs
@@ -17,7 +17,11 @@ module Codec.Compression.BZip.Internal (
   decompress,
 
   -- * Monadic incremental interface
+  -- $incremental-compression
+
   -- ** Incremental compression
+  -- $using-incremental-compression
+
   CompressStream(..),
   compressST,
   compressIO,
@@ -25,6 +29,8 @@ module Codec.Compression.BZip.Internal (
   foldCompressStreamWithInput,
 
   -- ** Incremental decompression
+  -- $using-incremental-decompression
+
   DecompressStream(..),
   DecompressError(..),
   decompressST,
@@ -123,6 +129,75 @@ defaultCompressBufferSize, defaultDecompressBufferSize :: Int
 defaultCompressBufferSize   = 16 * 1024 - L.chunkOverhead
 defaultDecompressBufferSize = 32 * 1024 - L.chunkOverhead
 
+-- $incremental-compression
+-- The pure 'Codec.Compression.BZip.Internal.compress' and
+-- 'Codec.Compression.BZip.Internal.decompress' functions are streaming in the sense
+-- that they can produce output without demanding all input, however they need
+-- the input data stream as a lazy 'L.ByteString'. Having the input data
+-- stream as a lazy 'L.ByteString' often requires using lazy I\/O which is not
+-- appropriate in all circumstances.
+--
+-- For these cases an incremental interface is more appropriate. This interface
+-- allows both incremental input and output. Chunks of input data are supplied
+-- one by one (e.g. as they are obtained from an input source like a file or
+-- network source). Output is also produced chunk by chunk.
+--
+-- The incremental input and output is managed via the 'CompressStream' and
+-- 'DecompressStream' types. They represent the unfolding of the process of
+-- compressing and decompressing. They operates in either the 'ST' or 'IO'
+-- monads. They can be lifted into other incremental abstractions like pipes or
+-- conduits, or they can be used directly in the following style.
+
+-- $using-incremental-compression
+--
+-- In a loop:
+--
+--  * Inspect the status of the stream
+--
+--  * When it is 'CompressInputRequired' then you should call the action,
+--    passing a chunk of input (or 'BS.empty' when no more input is available)
+--    to get the next state of the stream and continue the loop.
+--
+--  * When it is 'CompressOutputAvailable' then do something with the given
+--    chunk of output, and call the action to get the next state of the stream
+--    and continue the loop.
+--
+--  * When it is 'CompressStreamEnd' then terminate the loop.
+--
+-- Note that you cannot stop as soon as you have no more input, you need to
+-- carry on until all the output has been collected, i.e. until you get to
+-- 'CompressStreamEnd'.
+--
+-- Here is an example where we get input from one file handle and send the
+-- compressed output to another file handle.
+--
+-- > go :: Handle -> Handle -> CompressStream IO -> IO ()
+-- > go inh outh (CompressInputRequired next) = do
+-- >    inchunk <- BS.hGet inh 4096
+-- >    go inh outh =<< next inchunk
+-- > go inh outh (CompressOutputAvailable outchunk next) =
+-- >    BS.hPut outh outchunk
+-- >    go inh outh =<< next
+-- > go _ _ CompressStreamEnd = return ()
+--
+-- The same can be achieved with 'foldCompressStream':
+--
+-- > foldCompressStream
+-- >   (\next -> do inchunk <- BS.hGet inh 4096; next inchunk)
+-- >   (\outchunk next -> do BS.hPut outh outchunk; next)
+-- >   (return ())
+
+-- $using-incremental-decompression
+--
+-- The use of 'DecompressStream' is very similar to 'CompressStream' but with
+-- a few differences:
+--
+-- * There is the extra possibility of a 'DecompressStreamError'
+--
+-- * There can be extra trailing data after a compressed stream, and the
+--   'DecompressStreamEnd' includes that.
+--
+-- Otherwise the same loop style applies, and there are fold functions.
 
 -- | The unfolding of the compression process, where you provide a sequence
 -- of uncompressed data chunks as input and receive a sequence of compressed
@@ -146,11 +221,27 @@ data CompressStream m =
 -- One way to look at this is that it runs the stream, using callback functions
 -- for the three stream events.
 --
-foldCompressStream :: Monad m
-                   => ((S.ByteString -> m a) -> m a)
-                   -> (S.ByteString -> m a -> m a)
-                   -> m a
-                   -> CompressStream m -> m a
+foldCompressStream 
+  :: Monad m
+  -- | How to obtain more input to be compressed.
+  -- Typically, this is a lambda of the form
+  -- 
+  -- > \consume -> do { bs <- obtainData ; consume bs }
+  -- 
+  => ((S.ByteString -> m a) -> m a)
+  -- | The right-folding operation. Note that the 
+  -- second argument is already embedded in the
+  -- monad.
+  -> (S.ByteString -> m a -> m a)
+  -- | The base value of the fold. If the output
+  -- is itself a 'L.ByteString', this can just
+  -- be (return 'L.empty').
+  -> m a
+  -- | The input stream. Typically, this is
+  -- ('compressIO' params) or ('compressST' params),
+  -- depending on the choice of monad.
+  -> CompressStream m 
+  -> m a
 foldCompressStream input output end = fold
   where
     fold (CompressInputRequired next) =
@@ -171,11 +262,19 @@ foldCompressStream input output end = fold
 --
 -- > toChunks = foldCompressStreamWithInput (:) []
 --
-foldCompressStreamWithInput :: (S.ByteString -> a -> a)
-                            -> a
-                            -> (forall s. CompressStream (ST s))
-                            -> L.ByteString
-                            -> a
+foldCompressStreamWithInput 
+  -- | The right-folding operation, used to create output.
+  -- In typical usage, this is 'L.chunk'.
+  :: (S.ByteString -> a -> a)
+  -- | The base value of the fold. In typical usage,
+  -- this is just 'L.empty' or 'mempty'.
+  -> a
+  -- | The compression stream. Typically, this is
+  -- ('compressST' params).
+  -> (forall s. CompressStream (ST s))
+  -- | The input lazy 'L.ByteString'.
+  -> L.ByteString
+  -> a
 foldCompressStreamWithInput chunk end = \s lbs ->
     runST (fold s (L.toChunks lbs))
   where
@@ -192,8 +291,24 @@ foldCompressStreamWithInput chunk end = \s lbs ->
     fold CompressStreamEnd _inchunks =
       return end
 
+-- | Compress a data stream provided as a lazy 'L.ByteString'.
+--
+-- There are no expected error conditions. All input data streams are valid. It
+-- is possible for unexpected errors to occur, such as running out of memory,
+-- or finding the wrong version of the bz2 C library; these are thrown as
+-- exceptions.
+--
 compress   :: CompressParams -> L.ByteString -> L.ByteString
+
+-- | Incremental compression in the 'ST' monad. Using 'ST' makes it possible
+-- to write pure /lazy/ functions while making use of incremental compression.
+--
+-- Chunk size must fit into t'CUInt'.
 compressST :: CompressParams -> CompressStream (ST s)
+
+-- | Incremental compression in the 'IO' monad.
+--
+-- Chunk size must fit into t'CUInt'.
 compressIO :: CompressParams -> CompressStream IO
 
 compress   params = foldCompressStreamWithInput
@@ -202,6 +317,7 @@ compress   params = foldCompressStreamWithInput
 compressST params = compressStreamST params
 compressIO params = compressStreamIO params
 
+-- | Chunk size must fit into t'CUInt'.
 compressStream
   :: CompressParams -> S.ByteString -> Stream (CompressStream Stream)
 compressStream (CompressParams blockSize workFactor initChunkSize) =
@@ -285,7 +401,11 @@ compressStream (CompressParams blockSize workFactor initChunkSize) =
 
       Stream.Error _ msg -> fail msg
 
-
+-- | The unfolding of the decompression process, where you provide a sequence
+-- of compressed data chunks as input and receive a sequence of uncompressed
+-- data chunks as output. The process is incremental, in that the demand for
+-- input and provision of output are interleaved.
+--
 data DecompressStream m =
 
      DecompressInputRequired {
@@ -307,8 +427,16 @@ data DecompressStream m =
          decompressStreamError :: DecompressError
        }
 
+-- | The possible error cases when decompressing a stream.
+--
+-- This can be 'show'n to give a human readable error message.
+--
 data DecompressError =
+     -- | The compressed data stream ended prematurely. This may happen if the
+     -- input data stream was truncated.
      TruncatedInput
+     -- | If the compressed data stream is corrupted in any way then you will
+     -- get this error.
    | DataFormatError String
 
 instance Show DecompressError where
@@ -320,12 +448,37 @@ modprefix = ("Codec.Compression.BZip: " ++)
 
 instance Exception DecompressError
 
-foldDecompressStream :: Monad m
-                     => ((S.ByteString -> m a) -> m a)
-                     -> (S.ByteString -> m a -> m a)
-                     -> (S.ByteString -> m a)
-                     -> (DecompressError -> m a)
-                     -> DecompressStream m -> m a
+-- | A fold over the 'DecompressStream' in the given monad.
+--
+-- One way to look at this is that it runs the stream, using callback functions
+-- for the four stream events.
+--
+foldDecompressStream 
+  :: Monad m
+  -- | How to obtain more input for the decompression
+  -- stream. Typically, this is a lambda of the form
+  -- 
+  -- > \consume -> do { bs <- obtainData ; consume bs }
+  -- 
+  => ((S.ByteString -> m a) -> m a)
+  -- | The right-folding operation. Note that the 
+  -- second argument is already embedded in the
+  -- monad.
+  -> (S.ByteString -> m a -> m a)
+  -- | How to handle any trailing data after
+  -- decompression is completed. To ignore it,
+  -- just pass @const (return bas)@, where @bas@
+  -- is the base value of the right-fold operation.
+  -> (S.ByteString -> m a)
+  -- | How to handle errors. Typically, this is
+  -- 'throw', but it can be e.g. (return . 'Left')
+  -- if the output value is wrapped in 'Either'.
+  -> (DecompressError -> m a)
+  -- | The input stream. Typically, this is
+  -- ('decompressIO' params) or ('decompressST' params),
+  -- depending on the choice of monad.
+  -> DecompressStream m 
+  -> m a
 foldDecompressStream input output end err = fold
   where
     fold (DecompressInputRequired next) =
@@ -337,12 +490,38 @@ foldDecompressStream input output end err = fold
     fold (DecompressStreamEnd inchunk) = end inchunk
     fold (DecompressStreamError derr)  = err derr
 
-foldDecompressStreamWithInput :: (S.ByteString -> a -> a)
-                              -> (L.ByteString -> a)
-                              -> (DecompressError -> a)
-                              -> (forall s. DecompressStream (ST s))
-                              -> L.ByteString
-                              -> a
+-- | A variant on 'foldDecompressStream' that is pure rather than operating in a
+-- monad and where the input is provided by a lazy 'L.ByteString'. So we only
+-- have to deal with the output, end and error parts, making it like a foldr on
+-- a list of output chunks.
+--
+-- For example:
+--
+-- > toChunks params = foldDecompressStreamWithInput (:) (const []) throw (decompressST params)
+--
+-- or
+--
+-- > import qualified Data.ByteString.Lazy          as L
+-- > import qualified Data.ByteString.Lazy.Internal as L
+-- >
+-- > compressWith params = foldDecompressStreamWithInput (L.chunk) (const L.empty) throw (decompressST params)
+--
+foldDecompressStreamWithInput 
+  -- | The right-folding operation, used to create output.
+  -- In typical usage, this is 'L.chunk'.
+  :: (S.ByteString -> a -> a)
+  -- | How to handle any trailing data; typically, this
+  -- is discarded. 
+  -> (L.ByteString -> a)
+  -- | How to handle any errors. To raise this as an
+  -- error, just use 'throw'.
+  -> (DecompressError -> a)
+  -- | The decompression stream. Typically, this is
+  -- ('decompressST' params).
+  -> (forall s. DecompressStream (ST s))
+  -- | The input lazy `L.ByteString`.
+  -> L.ByteString
+  -> a
 foldDecompressStreamWithInput chunk end err = \s lbs ->
     runST (fold s (L.toChunks lbs))
   where
@@ -362,8 +541,23 @@ foldDecompressStreamWithInput chunk end err = \s lbs ->
     fold (DecompressStreamError derr) _ =
       return $ err derr
 
+-- | Decompress a data stream provided as a lazy 'L.ByteString'.
+--
+-- It will throw an exception if any error is encountered in the input data.
+-- If you need more control over error handling then use one the incremental
+-- versions, 'decompressST' or 'decompressIO'.
+--
 decompress   :: DecompressParams -> L.ByteString -> L.ByteString
+
+-- | Incremental decompression in the 'ST' monad. Using 'ST' makes it possible
+-- to write pure /lazy/ functions while making use of incremental decompression.
+--
+-- Chunk size must fit into t'CUInt'.
 decompressST :: DecompressParams -> DecompressStream (ST s)
+
+-- | Incremental decompression in the 'IO' monad.
+--
+-- Chunk size must fit into t'CUInt'.
 decompressIO :: DecompressParams -> DecompressStream IO
 
 decompress   params = foldDecompressStreamWithInput
@@ -372,6 +566,7 @@ decompress   params = foldDecompressStreamWithInput
 decompressST params = decompressStreamST params
 decompressIO params = decompressStreamIO params
 
+-- | Chunk size must fit into t'CUInt'.
 decompressStream
   :: DecompressParams -> S.ByteString -> Stream (DecompressStream Stream)
 decompressStream (DecompressParams memLevel initChunkSize) =

--- a/Codec/Compression/BZip/Internal.hs
+++ b/Codec/Compression/BZip/Internal.hs
@@ -26,6 +26,7 @@ module Codec.Compression.BZip.Internal (
 
   -- ** Incremental decompression
   DecompressStream(..),
+  DecompressError(..),
   decompressST,
   decompressIO,
   foldDecompressStream,

--- a/Codec/Compression/BZip/Internal.hs
+++ b/Codec/Compression/BZip/Internal.hs
@@ -234,7 +234,7 @@ foldCompressStream
   -- second argument is already embedded in the
   -- monad. This is typically a lambda of the form
   -- 
-  -- > \chunk next -> L.chunk chunk <$> next
+  -- > \chunk next -> Data.ByteString.Lazy.chunk chunk <$> next
   -- 
   -- or
   --
@@ -243,10 +243,10 @@ foldCompressStream
   -> m a
   -- ^ The base value of the fold. If the output
   -- is itself a 'L.ByteString', this can just
-  -- be (return 'L.empty').
+  -- be (@return@ 'L.empty').
   -> CompressStream m 
   -- ^ The input stream. Typically, this is
-  -- ('compressIO' params) or ('compressST' params),
+  -- ('compressIO' @params@) or ('compressST' @params@),
   -- depending on the choice of monad.
   -> m a
 foldCompressStream input output end = fold
@@ -278,7 +278,7 @@ foldCompressStreamWithInput
   -- this is just 'L.empty' or 'mempty'.
   -> (forall s. CompressStream (ST s))
   -- ^ The compression stream. Typically, this is
-  -- ('compressST' params).
+  -- ('compressST' @params@).
   -> L.ByteString
   -- ^ The input lazy 'L.ByteString'.
   -> a
@@ -474,7 +474,7 @@ foldDecompressStream
   -- second argument is already embedded in the
   -- monad. This is typically a lambda of the form
   -- 
-  -- > \chunk next -> L.chunk chunk <$> next
+  -- > \chunk next -> Data.ByteString.Lazy.Internal.chunk chunk <$> next
   -- 
   -- or
   --
@@ -487,11 +487,11 @@ foldDecompressStream
   -- is the base value of the right-fold operation.
   -> (DecompressError -> m a)
   -- ^ How to handle errors. Typically, this is
-  -- 'throw', but it can be e.g. (return . 'Left')
+  -- 'throw', but it can be e.g. (@return@ . 'Left')
   -- if the output value is wrapped in 'Either'.
   -> DecompressStream m 
   -- ^ The input stream. Typically, this is
-  -- ('decompressIO' params) or ('decompressST' params),
+  -- ('decompressIO' @params@) or ('decompressST' @params@),
   -- depending on the choice of monad.
   -> m a
 foldDecompressStream input output end err = fold
@@ -519,7 +519,7 @@ foldDecompressStream input output end err = fold
 -- > import qualified Data.ByteString.Lazy          as L
 -- > import qualified Data.ByteString.Lazy.Internal as L
 -- >
--- > compressWith params = foldDecompressStreamWithInput (L.chunk) (const L.empty) throw (decompressST params)
+-- > decompressWith params = foldDecompressStreamWithInput (L.chunk) (const L.empty) throw (decompressST params)
 --
 foldDecompressStreamWithInput 
   :: (S.ByteString -> a -> a)
@@ -533,7 +533,7 @@ foldDecompressStreamWithInput
   -- error, just use 'throw'.
   -> (forall s. DecompressStream (ST s))
   -- ^ The decompression stream. Typically, this is
-  -- ('decompressST' params).  
+  -- ('decompressST' @params@).  
   -> L.ByteString
   -- ^ The input lazy `L.ByteString`.
   -> a
@@ -559,7 +559,7 @@ foldDecompressStreamWithInput chunk end err = \s lbs ->
 -- | Decompress a data stream provided as a lazy 'L.ByteString'.
 --
 -- It will throw an exception if any error is encountered in the input data.
--- If you need more control over error handling then use one the incremental
+-- If you need more control over error handling then use one of the incremental
 -- versions, 'decompressST' or 'decompressIO'.
 --
 decompress   :: DecompressParams -> L.ByteString -> L.ByteString

--- a/bzlib.cabal
+++ b/bzlib.cabal
@@ -1,5 +1,5 @@
 name:            bzlib
-version:         0.5.2.1
+version:         0.5.3.0
 copyright:       (c) 2006-2015 Duncan Coutts
 license:         BSD3
 license-file:    LICENSE

--- a/bzlib.cabal
+++ b/bzlib.cabal
@@ -1,5 +1,5 @@
 name:            bzlib
-version:         0.5.2.0
+version:         0.5.2.1
 copyright:       (c) 2006-2015 Duncan Coutts
 license:         BSD3
 license-file:    LICENSE


### PR DESCRIPTION
Functionally, this just adds `DecompressError(..)` to the export list of `Codec.Compression.BZip.Internal`, but it also adds
a lot of documentation to the `Internal` module from the corresponding functions from [zlib](https://hackage.haskell.org/package/zlib). I also added some documentation for the arguments of the `foldCompressStream`/etc... functions to improve clarity.

Also, I bumped the version number and updated the changelog, which I suspect I wasn't supposed to? This is my first time contributing upstream to a Haskell package, so I wasn't sure of the protocol.